### PR TITLE
Added Materialize to the master index.html file

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -19,7 +19,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <!-- Boostrap (Deprecated for SocialQs) -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    
+    <!-- Materialize - (Preferred approach over Bootstrap for SocialQs) -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+            
     <title>SocialQs</title>
   </head>
   <body>


### PR DESCRIPTION
Simple change adds Materialize to /public/index.html.   

Need to be careful here because the Bootstrap library is still included.  We should pull out Bootstrap and sample Contacts code as soon as the first component is developed. 