### PR TITLE
corrected name of travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,4 @@ cache:
   directories:
   - node_modules
 script:
-  - npm test
   - npm run build
-deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $github_token
-  local_dir: build
-  on:
-    branch: master


### PR DESCRIPTION
Travis.yml files actually start with a "."   It is needed to kick off the build