### PR TITLE
added safety check to handler call to avoid null point events

### DIFF
--- a/client/src/pages/landingPage.js
+++ b/client/src/pages/landingPage.js
@@ -36,8 +36,9 @@ class LandingPage extends Component {
         console.log(response);
         if (response.status === 200) {
           // update App.js state
-          this.props.handlers.userUpdateHandler(true, response.data);
-
+          if (this.props.handlers !== undefined) {
+            this.props.handlers.userUpdateHandler(true, response.data);
+          }
           // update the state to redirect to home
           this.setState({
             redirectTo: "/",


### PR DESCRIPTION
Navigating from an empty page such as "Manage Events" may cause an error as the state isn't maintained.  This is just a small fix to avoid that console message.